### PR TITLE
Console Button & Disguise Kit Fix

### DIFF
--- a/resource/gamemenu.res
+++ b/resource/gamemenu.res
@@ -84,6 +84,14 @@
 		"tooltip" 		"Replays"
 	}
 
+	"ConsoleButton"
+	{
+		"label"			">_"
+		"command"		"engine toggleconsole"
+		"subimage" 		""
+		"tooltip" 		"Console"
+	}
+
 
 	"SafeModeButton"
 	{

--- a/resource/ui/disguise_menu/hudmenuspydisguise.res
+++ b/resource/ui/disguise_menu/hudmenuspydisguise.res
@@ -381,8 +381,8 @@
 	{
 		"ControlName"	"CIconPanel"
 		"fieldName"		"NumberBg"
-		"xpos"			"75"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"4"
 		"wide"			"15"
 		"tall"			"15"
@@ -391,6 +391,8 @@
 		"scaleImage"	"1"	
 		"icon"			"ico_key_blank"
 		"iconColor"		"255 255 255 255"
+
+		"pin_to_sibling"	"class_item_red_2"
 	}
 	
 	"NumberLabel1"
@@ -399,8 +401,8 @@
 		"fieldName"		"NumberLabel"
 		"font"			"Default"
 		"fgcolor"		"Black"
-		"xpos"			"75"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"5"
 		"wide"			"15"
 		"tall"			"15"
@@ -411,15 +413,16 @@
 		"labelText"		"1"
 		"textAlignment"	"Center"
 		"dulltext"		"1"
-		
+
+		"pin_to_sibling"	"class_item_red_2"
 	}
 
 	"NumberBg2"
 	{
 		"ControlName"	"CIconPanel"
 		"fieldName"		"NumberBg"
-		"xpos"			"227"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"4"
 		"wide"			"15"
 		"tall"			"15"
@@ -428,6 +431,8 @@
 		"scaleImage"	"1"	
 		"icon"			"ico_key_blank"
 		"iconColor"		"255 255 255 255"
+
+		"pin_to_sibling"	"class_item_red_5"
 	}
 	
 	"NumberLabel2"
@@ -436,8 +441,8 @@
 		"fieldName"		"NumberLabel"
 		"font"			"Default"
 		"fgcolor"		"Black"
-		"xpos"			"227"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"5"
 		"wide"			"15"
 		"tall"			"15"
@@ -448,6 +453,8 @@
 		"labelText"		"2"
 		"textAlignment"	"Center"
 		"dulltext"		"1"
+
+		"pin_to_sibling"	"class_item_red_5"
 		
 	}
 	
@@ -455,8 +462,8 @@
 	{
 		"ControlName"	"CIconPanel"
 		"fieldName"		"NumberBg"
-		"xpos"			"379"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"4"
 		"wide"			"15"
 		"tall"			"15"
@@ -465,6 +472,8 @@
 		"scaleImage"	"1"	
 		"icon"			"ico_key_blank"
 		"iconColor"		"255 255 255 255"
+
+		"pin_to_sibling"	"class_item_red_8"
 	}
 	
 	"NumberLabel3"
@@ -473,8 +482,8 @@
 		"fieldName"		"NumberLabel"
 		"font"			"Default"
 		"fgcolor"		"Black"
-		"xpos"			"379"
-		"ypos"			"140"
+		"xpos"			"-15"
+		"ypos"			"-90"
 		"zpos"			"5"
 		"wide"			"15"
 		"tall"			"15"
@@ -485,6 +494,8 @@
 		"labelText"		"3"
 		"textAlignment"	"Center"
 		"dulltext"		"1"
+
+		"pin_to_sibling"	"class_item_red_8"
 		
 	}
 }

--- a/resource/ui/loop_base/mainmenu_extras.res
+++ b/resource/ui/loop_base/mainmenu_extras.res
@@ -243,6 +243,63 @@
             }
         }// end replaybutton
 
+        "ConsoleButton"
+        {
+            "ControlName"	"EditablePanel"
+            "fieldName"		"ConsoleButton"
+            "xpos"			"2"
+            "ypos"			"0"
+            "zpos"			"1"
+            "wide"			"32"
+            "tall"			"32"
+            "visible"		"1"
+            "enabled"		"1"
+            
+            "proportionaltoparent"  "1"
+
+            "pin_to_sibling"	    "ReplayButton"
+            "pin_to_sibling_corner"	"PIN_CENTER_RIGHT"
+		    "pin_corner_to_sibling"	"PIN_CENTER_LEFT"
+
+            SubButton 
+            {
+                "ControlName"	"CExImageButton"
+				"fieldName"		"SubButton"
+				"wide"			"32"
+				"tall"			"32"
+				"visible"		"1"
+				"enabled"		"1"
+
+                "labelText"		""
+                "font"			"futura-demi-20"
+                "textAlignment"	"center"
+
+                "sound_armed"		"UI/buttonrollover.wav"
+                "sound_depressed"	"UI/buttonclick.wav"
+
+                "paintbackground"	"0"
+                "paintborder"		"1"
+                "border_default"	"default_roundsmaller"
+                "border_armed"		"armed_roundsmaller"
+
+                "defaultfgcolor_override"    "255 255 255 255" //loop_offwhite
+                "armedfgcolor_override"      "0 0 0 255"
+
+                SubImage
+                {
+                    "ControlName"	"ImagePanel"
+			        "fieldName"		"SubImage"
+                    "xpos"			"cs-0.5"
+                    "ypos"			"cs-0.5"
+                    "wide"          "16"
+                    "tall"          "16"
+                    "scaleimage"    "1"
+
+                    "proportionaltoparent"  "1"
+                }
+            }
+        }// end consolebutton
+
 
         "GeneralStoreButton"
         {


### PR DESCRIPTION
Added a console button to the extras section of the main menu, for poor sods like myself who can't open it with the keybind. Also fixed the concise disguise kit numbers for spy.